### PR TITLE
Landmark redesign

### DIFF
--- a/anotathor.kv
+++ b/anotathor.kv
@@ -47,12 +47,28 @@
       id: save
 
     Scaler:
-      size_hint_y: 0.4
+      size_hint_y: 0.2
       orientation: "horizontal"
       id: anotationsize
       min: 0.0
       max: 1.0
       value: 0.5
+
+    BoxLayout:
+      canvas.before:
+        Color:
+          rgba: (0.1, 0.1, 0.1, 0.5)
+        Rectangle:
+          pos: self.pos
+          size: self.size
+      size_hint_y: 0.2
+      orientation: "vertical"
+      Label:
+        text: "Anotations:"
+      Label:
+        id: anotationnumber
+        # text: root.anotationNumber
+
 
     Button:
       size_hint_y: 0.2

--- a/kvClasses/landmark.kv
+++ b/kvClasses/landmark.kv
@@ -1,10 +1,16 @@
 <Landmark>:
   canvas.after:
     Color:
-      rgb: (0.1, 1, 0.1)
-    Rectangle:
-      pos: (self.x, self.y)
-      size: (self.width, self.height)
+      rgba: (1, 0, 0, 0.3)
+    Ellipse:
+      pos: self.pos
+      size: self.size
+
+    Color:
+      rgba: (0, 0, 0, 1)
+    Ellipse:
+      pos: (self.center_x - self.width/10, self.center_y - self.height/10)
+      size: (self.width/5, self.height/5)
 
   size_hint: (None, None)
   width: self.scaler.value*self.max_width

--- a/kvClasses/landmark.kv
+++ b/kvClasses/landmark.kv
@@ -1,7 +1,7 @@
 <Landmark>:
   canvas.after:
     Color:
-      rgba: (1, 0, 0, 0.3)
+      rgba: (1, 0, 0, 0.15)
     Ellipse:
       pos: self.pos
       size: self.size

--- a/pyClasses/landmark.py
+++ b/pyClasses/landmark.py
@@ -2,11 +2,11 @@ from kivy.uix.widget import Widget
 from kivy.uix.behaviors import DragBehavior
 from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.slider import Slider
-from kivy.properties import ObjectProperty
 
 class Landmark(DragBehavior, ButtonBehavior, Widget):
   max_width = 80
   max_height = 80
+
   def __init__(self, slider, *args, **kwargs):
     self.scaler = slider
     super(Landmark, self).__init__(*args, **kwargs)

--- a/pyClasses/landmark.py
+++ b/pyClasses/landmark.py
@@ -5,8 +5,8 @@ from kivy.uix.slider import Slider
 from kivy.properties import ObjectProperty
 
 class Landmark(DragBehavior, ButtonBehavior, Widget):
-  max_width = 20
-  max_height = 20
+  max_width = 80
+  max_height = 80
   def __init__(self, slider, *args, **kwargs):
     self.scaler = slider
     super(Landmark, self).__init__(*args, **kwargs)

--- a/pyClasses/mainbox.py
+++ b/pyClasses/mainbox.py
@@ -71,11 +71,19 @@ class MainBox(BoxLayout):
 
   def saveShape(self, landmarkParent, *args, **kwargs):
     coords = []
+    relative = []
+
+    imageSize = landmarkParent.norm_image_size
+    pic_zero = list(map( lambda x: x[0] - x[1]/2 , zip(landmarkParent.center, imageSize) ) )
+
     for child in landmarkParent.children:
       if isinstance(child, Landmark):
+        relative_x = (child.center[0] - pic_zero[0])/imageSize[0]
+        relative_y = (child.center[1] - pic_zero[1])/imageSize[1]
+        relative.append((relative_x, relative_y))
         coords.append(child.center)
 
-    dataPoint = {'imgName': self.nextList[len(self.nextList)-1], 'coords': coords}
+    dataPoint = {'imgName': self.nextList[len(self.nextList)-1], 'coords': coords, 'relative': relative}
     jsonString = json.dumps(dataPoint)
 
     with open('landmarks.json', 'a') as saveFile:

--- a/pyClasses/mainbox.py
+++ b/pyClasses/mainbox.py
@@ -58,6 +58,12 @@ class MainBox(BoxLayout):
     reloadButton.on_press()
     self.ids.anotationsize.landmarkParent = landmarkParent
 
+    # Property bindings
+    landmarkParent.bind(children=self.anotationNumberDisplay)
+
+  def anotationNumberDisplay(self, object, children):
+    self.ids.anotationnumber.text=str(len(children))
+
   def clearLandmarks(self, landmarkParent, *args, **kwargs):
     for child in list(landmarkParent.children):
       if isinstance(child, Landmark):


### PR DESCRIPTION
Added display for displaying annotation number, changed the design of landmarks to be semitransparent circles with a black dot in the middle. Saving landmarks now also saves coordinates relative to the picture.